### PR TITLE
feat: Allow overriding the whole assume policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ No resources.
 | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | The name of the IAM policy that is visible in the IAM policy manager | `string` | `null` | no |
 | <a name="input_principals"></a> [principals](#input\_principals) | Map of service name as key and a list of ARNs to allow assuming the role as value (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | `map(list(string))` | `{}` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_assume_role_policy"></a> [assume_role_policy](#input_assume_role_policy) | A JSON assume role policy document. If set, this will be used as the assume role policy and the principals, assume_role_conditions, and assume_role_actions variables will be ignored. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | The description of the IAM role that is visible in the IAM role manager | `string` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tags_enabled"></a> [tags\_enabled](#input\_tags\_enabled) | Enable/disable tags on IAM roles and policies | `string` | `true` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]`) will be used.<br/>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
 

--- a/README.yaml
+++ b/README.yaml
@@ -117,11 +117,11 @@ description: |-
   | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | The name of the IAM policy that is visible in the IAM policy manager | `string` | `null` | no |
   | <a name="input_principals"></a> [principals](#input\_principals) | Map of service name as key and a list of ARNs to allow assuming the role as value (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | `map(list(string))` | `{}` | no |
   | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+  | <a name="input_assume_role_policy"></a> [assume_role_policy](#input_assume_role_policy) | A JSON assume role policy document. If set, this will be used as the assume role policy and the principals, assume_role_conditions, and assume_role_actions variables will be ignored. | `string` | `null` | no |
   | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
   | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | The description of the IAM role that is visible in the IAM role manager | `string` | n/a | yes |
   | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
   | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-  | <a name="input_tags_enabled"></a> [tags\_enabled](#input\_tags\_enabled) | Enable/disable tags on IAM roles and policies | `string` | `true` | no |
   | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
   | <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]`) will be used.<br>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
 

--- a/src/README.md
+++ b/src/README.md
@@ -121,11 +121,11 @@ No resources.
 | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | The name of the IAM policy that is visible in the IAM policy manager | `string` | `null` | no |
 | <a name="input_principals"></a> [principals](#input\_principals) | Map of service name as key and a list of ARNs to allow assuming the role as value (e.g. map(`AWS`, list(`arn:aws:iam:::role/admin`))) | `map(list(string))` | `{}` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_assume_role_policy"></a> [assume_role_policy](#input_assume_role_policy) | A JSON assume role policy document. If set, this will be used as the assume role policy and the principals, assume_role_conditions, and assume_role_actions variables will be ignored. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | The description of the IAM role that is visible in the IAM role manager | `string` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tags_enabled"></a> [tags\_enabled](#input\_tags\_enabled) | Enable/disable tags on IAM roles and policies | `string` | `true` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 | <a name="input_use_fullname"></a> [use\_fullname](#input\_use\_fullname) | If set to 'true' then the full ID for the IAM role name (e.g. `[var.namespace]-[var.environment]-[var.stage]`) will be used.<br/>Otherwise, `var.name` will be used for the IAM role name. | `bool` | `true` | no |
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -4,10 +4,11 @@ locals {
 
 module "role" {
   source  = "cloudposse/iam-role/aws"
-  version = "0.17.0"
+  version = "0.22.0"
 
   assume_role_actions      = var.assume_role_actions
   assume_role_conditions   = var.assume_role_conditions
+  assume_role_policy       = var.assume_role_policy
   instance_profile_enabled = var.instance_profile_enabled
   managed_policy_arns      = var.managed_policy_arns
   max_session_duration     = var.max_session_duration
@@ -19,7 +20,6 @@ module "role" {
   policy_name              = var.policy_name
   principals               = var.principals
   role_description         = var.role_description
-  tags_enabled             = var.tags_enabled
   use_fullname             = var.use_fullname
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -93,8 +93,8 @@ variable "path" {
   default     = "/"
 }
 
-variable "tags_enabled" {
+variable "assume_role_policy" {
   type        = string
-  description = "Enable/disable tags on IAM roles and policies"
-  default     = true
+  description = "A JSON assume role policy document. If set, this will be used as the assume role policy and the principals, assume_role_conditions, and assume_role_actions variables will be ignored."
+  default     = null
 }

--- a/test/fixtures/stacks/catalog/usecase/assume_role_policy.yaml
+++ b/test/fixtures/stacks/catalog/usecase/assume_role_policy.yaml
@@ -1,0 +1,30 @@
+components:
+  terraform:
+    iam-role/assume-role-policy:
+      metadata:
+        component: target
+      vars:
+        name: assume-role-policy-role
+        use_fullname: true
+        role_description: |
+          Used for testing assume_role_policy override.
+        assume_role_policy: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {"Service": "ec2.amazonaws.com"},
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          }
+        policy_document_count: 0
+        managed_policy_arns:
+          - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+        max_session_duration: 3600
+        permissions_boundary: "arn:aws:iam::aws:policy/PowerUserAccess"
+        policy_name: assume-role-policy-test
+        policy_description: "IAM policy for testing assume_role_policy override."
+        instance_profile_enabled: false
+        path: "/" 

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -49,4 +49,3 @@ components:
               - "staging"
         instance_profile_enabled: true
         path: "/"
-        tags_enabled: true

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -50,4 +50,3 @@ components:
               - "staging"
         instance_profile_enabled: true
         path: "/"
-        tags_enabled: true

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -2,3 +2,4 @@ import:
   - orgs/default/test/_defaults
   - catalog/usecase/basic
   - catalog/usecase/disabled
+  - catalog/usecase/assume_role_policy


### PR DESCRIPTION
## what
* Update the terraform-aws-iam-role module to [v0.22.0](https://github.com/cloudposse/terraform-aws-iam-role/releases/tag/v0.22.0).
  * See the changes introduced: https://github.com/cloudposse/terraform-aws-iam-role/compare/0.17.0...v0.22.0
  * Removing tags-enabled variable as it was removed by https://github.com/cloudposse/terraform-aws-iam-role/releases/tag/v0.21.0

## why
* To bring the latest fixes and features from the Terraform module to the Atmos component.

## references

* https://github.com/cloudposse/terraform-aws-iam-role/releases/tag/v0.22.0
* https://github.com/cloudposse/terraform-aws-iam-role/pull/86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for providing a custom JSON assume role policy, allowing users to override default assume role policy behavior.

- **Bug Fixes**
  - Removed the `tags_enabled` input variable and related configuration.

- **Documentation**
  - Updated documentation to reflect the new `assume_role_policy` input and the removal of `tags_enabled`.

- **Tests**
  - Introduced new test cases and configurations to validate the custom assume role policy functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->