### PR TITLE
feat: add EKS OIDC provider support for IRSA

### DIFF
--- a/src/eks-assume-role-policy.tf
+++ b/src/eks-assume-role-policy.tf
@@ -53,8 +53,9 @@ variable "service_account_namespace" {
 locals {
   eks_oidc_enabled = local.enabled && var.eks_oidc_provider_enabled
 
-  # Default service account namespace and name to the component name if not specified
-  # Use try() to handle the case when module.this.name is empty (e.g., when enabled=false)
+  # Default service account namespace and name to module.this.name if not specified.
+  # Only evaluated when eks_oidc_enabled is true, which guarantees module.this.name is non-empty.
+  # coalesce() returns the first non-null, non-empty argument.
   service_account_namespace = local.eks_oidc_enabled ? coalesce(var.service_account_namespace, module.this.name) : ""
   service_account_name      = local.eks_oidc_enabled ? coalesce(var.service_account_name, module.this.name) : ""
 

--- a/src/eks-assume-role-policy.tf
+++ b/src/eks-assume-role-policy.tf
@@ -16,7 +16,7 @@ variable "eks_oidc_provider_arn" {
   default     = ""
 
   validation {
-    condition     = !local.eks_oidc_enabled || var.eks_oidc_provider_arn != ""
+    condition     = !var.eks_oidc_provider_enabled || var.eks_oidc_provider_arn != ""
     error_message = "eks_oidc_provider_arn must be set if EKS OIDC provider is enabled"
   }
 }
@@ -54,8 +54,9 @@ locals {
   eks_oidc_enabled = local.enabled && var.eks_oidc_provider_enabled
 
   # Default service account namespace and name to the component name if not specified
-  service_account_namespace = coalesce(var.service_account_namespace, module.this.name)
-  service_account_name      = coalesce(var.service_account_name, module.this.name)
+  # Use try() to handle the case when module.this.name is empty (e.g., when enabled=false)
+  service_account_namespace = local.eks_oidc_enabled ? coalesce(var.service_account_namespace, module.this.name) : ""
+  service_account_name      = local.eks_oidc_enabled ? coalesce(var.service_account_name, module.this.name) : ""
 
   # Extract OIDC issuer URL from ARN if not explicitly provided
   # ARN format: arn:aws:iam::<account-id>:oidc-provider/<issuer-url>

--- a/src/eks-assume-role-policy.tf
+++ b/src/eks-assume-role-policy.tf
@@ -1,0 +1,117 @@
+# EKS OIDC / IRSA support for IAM roles
+# Allows Kubernetes service accounts to assume this IAM role
+
+variable "eks_oidc_provider_enabled" {
+  type        = bool
+  description = "Enable EKS OIDC provider for IRSA (IAM Roles for Service Accounts)"
+  default     = false
+}
+
+variable "eks_oidc_provider_arn" {
+  type        = string
+  description = <<-EOT
+    ARN of the EKS OIDC provider. Required when eks_oidc_provider_enabled is true.
+    Format: arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<cluster-id>
+    EOT
+  default     = ""
+
+  validation {
+    condition     = !local.eks_oidc_enabled || var.eks_oidc_provider_arn != ""
+    error_message = "eks_oidc_provider_arn must be set if EKS OIDC provider is enabled"
+  }
+}
+
+variable "eks_oidc_issuer_url" {
+  type        = string
+  description = <<-EOT
+    The OIDC issuer URL from the EKS cluster (without https:// prefix).
+    Format: oidc.eks.<region>.amazonaws.com/id/<cluster-id>
+    If not specified, it will be derived from eks_oidc_provider_arn.
+    EOT
+  default     = ""
+}
+
+variable "service_account_name" {
+  type        = string
+  description = <<-EOT
+    The name of the Kubernetes service account allowed to assume this role.
+    Use '*' to allow any service account in the namespace.
+    Defaults to module.this.name if not specified.
+    EOT
+  default     = null
+}
+
+variable "service_account_namespace" {
+  type        = string
+  description = <<-EOT
+    The Kubernetes namespace of the service account allowed to assume this role.
+    Defaults to module.this.name if not specified.
+    EOT
+  default     = null
+}
+
+locals {
+  eks_oidc_enabled = local.enabled && var.eks_oidc_provider_enabled
+
+  # Default service account namespace and name to the component name if not specified
+  service_account_namespace = coalesce(var.service_account_namespace, module.this.name)
+  service_account_name      = coalesce(var.service_account_name, module.this.name)
+
+  # Extract OIDC issuer URL from ARN if not explicitly provided
+  # ARN format: arn:aws:iam::<account-id>:oidc-provider/<issuer-url>
+  eks_oidc_issuer_url = local.eks_oidc_enabled ? coalesce(
+    var.eks_oidc_issuer_url,
+    try(regex("oidc-provider/(.+)$", var.eks_oidc_provider_arn)[0], "")
+  ) : ""
+
+  # Construct the subject claim for the service account
+  # Format: system:serviceaccount:<namespace>:<service-account-name>
+  eks_service_account_subject = local.eks_oidc_enabled ? "system:serviceaccount:${local.service_account_namespace}:${local.service_account_name}" : ""
+}
+
+data "aws_iam_policy_document" "eks_oidc_provider_assume" {
+  count = local.eks_oidc_enabled ? 1 : 0
+
+  statement {
+    sid = "EksOidcProviderAssume"
+    actions = [
+      "sts:AssumeRoleWithWebIdentity",
+      "sts:TagSession",
+    ]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.eks_oidc_provider_arn]
+    }
+
+    # Verify the audience is AWS STS
+    condition {
+      test     = "StringEquals"
+      variable = "${local.eks_oidc_issuer_url}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Restrict to specific namespace and service account
+    # Use StringLike to support wildcards in service account name
+    condition {
+      test     = local.service_account_name == "*" ? "StringLike" : "StringEquals"
+      variable = "${local.eks_oidc_issuer_url}:sub"
+      values   = [local.eks_service_account_subject]
+    }
+  }
+}
+
+output "eks_assume_role_policy" {
+  value       = local.eks_oidc_enabled ? one(data.aws_iam_policy_document.eks_oidc_provider_assume[*].json) : null
+  description = "JSON encoded string representing the EKS OIDC \"Assume Role\" policy"
+}
+
+output "eks_oidc_provider_arn" {
+  value       = local.eks_oidc_enabled ? var.eks_oidc_provider_arn : null
+  description = "ARN of the EKS OIDC provider (pass-through for reference)"
+}
+
+output "eks_service_account_subject" {
+  value       = local.eks_service_account_subject
+  description = "The service account subject claim used in the trust policy"
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -41,12 +41,13 @@ locals {
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
-  count = local.enabled && (var.assume_role_policy != null || local.github_oidc_enabled) ? 1 : 0
+  count = local.enabled && (var.assume_role_policy != null || local.github_oidc_enabled || local.eks_oidc_enabled) ? 1 : 0
 
-  # Merge assume_role_policy with GitHub OIDC policy if both exist
+  # Merge assume_role_policy with GitHub OIDC and EKS OIDC policies if they exist
   source_policy_documents = compact([
     var.assume_role_policy,
-    try(one(data.aws_iam_policy_document.github_oidc_provider_assume[*].json), null)
+    try(one(data.aws_iam_policy_document.github_oidc_provider_assume[*].json), null),
+    try(one(data.aws_iam_policy_document.eks_oidc_provider_assume[*].json), null)
   ])
 }
 
@@ -54,7 +55,7 @@ module "role" {
   source  = "cloudposse/iam-role/aws"
   version = "0.22.0"
 
-  assume_role_policy       = var.assume_role_policy != null || local.github_oidc_enabled ? one(data.aws_iam_policy_document.assume_role_policy[*].json) : null
+  assume_role_policy       = var.assume_role_policy != null || local.github_oidc_enabled || local.eks_oidc_enabled ? one(data.aws_iam_policy_document.assume_role_policy[*].json) : null
   assume_role_actions      = var.assume_role_actions
   assume_role_conditions   = var.assume_role_conditions
   instance_profile_enabled = var.instance_profile_enabled

--- a/test/fixtures/stacks/catalog/usecase/eks_oidc.yaml
+++ b/test/fixtures/stacks/catalog/usecase/eks_oidc.yaml
@@ -1,0 +1,28 @@
+components:
+  terraform:
+    iam-role/eks-oidc:
+      metadata:
+        component: target
+      vars:
+        name: eks-oidc-role
+        use_fullname: true
+        role_description: |
+          IRSA role for Kubernetes service accounts to access AWS resources.
+        # Enable EKS OIDC (IRSA)
+        eks_oidc_provider_enabled: true
+        # This will be overridden in the test with the actual provider ARN
+        eks_oidc_provider_arn: "arn:aws:iam::799847381734:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+        # Optional: explicitly set the issuer URL (derived from ARN by default)
+        # eks_oidc_issuer_url: "oidc.eks.us-east-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+        # Service account configuration
+        service_account_namespace: my-namespace
+        service_account_name: my-service-account
+        # Attach a managed policy for the role
+        policy_document_count: 0
+        managed_policy_arns:
+          - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        max_session_duration: 3600
+        policy_name: eks-oidc-policy
+        policy_description: "IAM policy for EKS IRSA role"
+        instance_profile_enabled: false
+        path: "/"

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -4,4 +4,5 @@ import:
   - catalog/usecase/disabled
   - catalog/usecase/assume_role_policy
   - catalog/usecase/github_oidc
+  - catalog/usecase/eks_oidc
   - catalog/usecase/policy_statements


### PR DESCRIPTION
## What

Add EKS OIDC provider support for IAM Roles for Service Accounts (IRSA), enabling Kubernetes workloads to assume IAM roles using their service account identity.

## Why

IRSA is the standard mechanism for granting AWS permissions to Kubernetes pods running in EKS. This complements the existing GitHub OIDC support by adding support for EKS workload identity.

## Features

- New `eks_oidc_provider_enabled` variable to enable EKS OIDC trust policy
- New `eks_oidc_provider_arn` variable for the EKS OIDC provider ARN
- New `eks_oidc_issuer_url` variable (optional - derived from ARN if not specified)
- New `service_account_name` and `service_account_namespace` variables to scope access
- Support for wildcard (`*`) service account names
- Automatic derivation of OIDC issuer URL from provider ARN
- Trust policy includes both `:aud` and `:sub` conditions for security

## Usage Example

```yaml
components:
  terraform:
    iam-role/my-app:
      metadata:
        component: iam-role
      vars:
        name: my-app
        role_description: "IRSA role for my-app"
        eks_oidc_provider_enabled: true
        eks_oidc_provider_arn: "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
        service_account_namespace: my-namespace
        service_account_name: my-service-account
        policy_statements:
          S3Access:
            effect: Allow
            actions:
              - "s3:GetObject"
            resources:
              - "arn:aws:s3:::my-bucket/*"
```

## References

- [AWS IRSA Documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
- Follows the same pattern as the existing GitHub OIDC support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EKS OIDC / IRSA support added with configuration for provider, issuer, service account namespace and name; exposes generated assume-role policy and service account subject as outputs.
* **Tests**
  * Added a test fixture for EKS OIDC/IRSA and included it in test runs to validate the configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->