### PR TITLE
feat: make EKS OIDC audience claim configurable

### DIFF
--- a/src/eks-assume-role-policy.tf
+++ b/src/eks-assume-role-policy.tf
@@ -31,6 +31,19 @@ variable "eks_oidc_issuer_url" {
   default     = ""
 }
 
+variable "eks_oidc_audience" {
+  type        = list(string)
+  description = <<-EOT
+    The expected `aud` (audience) claims on OIDC tokens presented when assuming this role.
+    Defaults to `["sts.amazonaws.com"]`, which is what AWS-managed EKS clusters use for IRSA.
+    Foreign OIDC providers (third-party SaaS vendors whose EKS cluster federates into
+    this account) may mint tokens with a different, vendor-specific audience — set this
+    to match the `aud` claim(s) they issue. A list is accepted to support trust policies
+    that need to accept tokens from multiple audiences (e.g., during an audience migration).
+    EOT
+  default     = ["sts.amazonaws.com"]
+}
+
 variable "service_account_name" {
   type        = string
   description = <<-EOT
@@ -86,11 +99,12 @@ data "aws_iam_policy_document" "eks_oidc_provider_assume" {
       identifiers = [var.eks_oidc_provider_arn]
     }
 
-    # Verify the audience is AWS STS
+    # Verify the audience claim matches what the OIDC provider issues
+    # (defaults to `sts.amazonaws.com` for AWS-managed EKS / IRSA)
     condition {
       test     = "StringEquals"
       variable = "${local.eks_oidc_issuer_url}:aud"
-      values   = ["sts.amazonaws.com"]
+      values   = var.eks_oidc_audience
     }
 
     # Restrict to specific namespace and service account


### PR DESCRIPTION
## what

Adds an `eks_oidc_audience` variable to `eks-assume-role-policy.tf`, allowing the expected `aud` claim in OIDC trust policies to be configured. Defaults to `["sts.amazonaws.com"]` — bit-for-bit backward compatible.

## why

The data source currently hardcodes `["sts.amazonaws.com"]` as the expected `aud` claim. That's correct for AWS-managed EKS clusters using IRSA, but **foreign EKS OIDC providers** (third-party SaaS vendors federating into an AWS account) mint tokens with vendor-specific audiences (often a UUID or custom string). Without a way to set this, the module can't be used for these federations.

## design notes

- **Backward compatible**: default `["sts.amazonaws.com"]` keeps existing trust policies byte-identical.
- **Typed `list(string)`** rather than `string`. The provider already expects a list at this position (`condition.values`), and a list lets consumers configure roles to accept tokens from multiple audiences during an audience migration (e.g. while a vendor is rotating their `aud` claim).
- No `validation` block on the value — empty list would produce an unconditioned policy, but the variable is only consumed when `eks_oidc_provider_enabled = true`, and the existing variable's validation behavior is similarly trust-the-caller.

## test

- `terraform fmt` clean
- `terraform validate` clean
- Existing module consumers see no diff in their plan output (default unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to customize OIDC audience claim values in EKS IAM role assumption policies, enabling flexibility for different authentication scenarios while maintaining backward compatibility with default settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse-terraform-components/aws-iam-role/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->